### PR TITLE
fix(label): move data-disabled logic to brn label, fix eslint rule

### DIFF
--- a/libs/ui/label/brain/.eslintrc.json
+++ b/libs/ui/label/brain/.eslintrc.json
@@ -6,6 +6,7 @@
 			"files": ["*.ts"],
 			"extends": ["plugin:@nx/angular", "plugin:@angular-eslint/template/process-inline-templates"],
 			"rules": {
+				"@angular-eslint/no-host-metadata-property": 0,
 				"@angular-eslint/directive-selector": [
 					"error",
 					{

--- a/libs/ui/label/brain/src/lib/brn-label.directive.ts
+++ b/libs/ui/label/brain/src/lib/brn-label.directive.ts
@@ -1,24 +1,43 @@
-import { Directive, HostBinding, Input, signal } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { Directive, ElementRef, inject, Input, OnInit, PLATFORM_ID, signal } from '@angular/core';
 
 let nextId = 0;
 
 @Directive({
 	selector: '[brnLabel]',
 	standalone: true,
+	host: {
+		'[id]': '_id()',
+	},
 })
-export class BrnLabelDirective {
-	@HostBinding('id')
-	get elementId() {
-		return this._id();
-	}
+export class BrnLabelDirective implements OnInit {
+	protected readonly _id = signal(`brn-label-${nextId++}`);
 
-	/* eslint-disable-next-line @angular-eslint/no-input-rename */
-	@Input('id')
+	@Input()
 	set id(id: string) {
 		this._id.set(id || this._id());
 	}
-	get id() {
-		return this._id();
+
+	private readonly _isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
+	private readonly _element = inject(ElementRef).nativeElement;
+	private _changes?: MutationObserver;
+	private readonly _dataDisabled = signal<boolean | 'auto'>('auto');
+	public readonly dataDisabled = this._dataDisabled.asReadonly();
+
+	ngOnInit(): void {
+		if (!this._isBrowser) return;
+		this._changes = new MutationObserver((mutations: MutationRecord[]) => {
+			mutations.forEach((mutation: MutationRecord) => {
+				if (mutation.attributeName !== 'data-disabled') return;
+				// eslint-disable-next-line
+				const state = (mutation.target as any).attributes.getNamedItem(mutation.attributeName)?.value === 'true';
+				this._dataDisabled.set(state ?? 'auto');
+			});
+		});
+		this._changes?.observe(this._element, {
+			attributes: true,
+			childList: true,
+			characterData: true,
+		});
 	}
-	readonly _id = signal(`brn-label-${nextId++}`);
 }


### PR DESCRIPTION
Moving some of the data-disabled logic to the brn label and using it in the hlm through DI of the host directive